### PR TITLE
Temporal Features

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -34,6 +34,7 @@ declare module '@docusaurus/plugin-content-docs-types' {
   export type PropSidebarItemCategory = PropsSidebarItemBase & {
     type: 'category';
     label: string;
+    link?: object;
     items: PropSidebarItem[];
     collapsed?: boolean;
   };

--- a/packages/docusaurus-plugin-content-docs/src/sidebars.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars.ts
@@ -97,7 +97,7 @@ function assertItem<K extends string>(
 function assertIsCategory(
   item: unknown,
 ): asserts item is SidebarItemCategoryJSON {
-  assertItem(item, ['items', 'label', 'collapsed', 'customProps']);
+  assertItem(item, ['items', 'label', 'collapsed', 'link', 'customProps']);
   if (typeof item.label !== 'string') {
     throw new Error(
       `Error loading ${JSON.stringify(item)}. "label" must be a string.`,

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -101,6 +101,7 @@ export type SidebarItemLink = SidebarItemBase & {
   type: 'link';
   href: string;
   label: string;
+  link?: object;
 };
 
 export type SidebarItemCategory = SidebarItemBase & {

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -87,6 +87,9 @@ function DocPageContent({
               sidebarCollapsible={
                 siteConfig.themeConfig?.sidebarCollapsible ?? true
               }
+              autoCollapseSidebar={
+                siteConfig.themeConfig?.autoCollapseSidebar ?? false
+              }
               onCollapse={toggleSidebar}
               isHidden={hiddenSidebar}
             />

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -79,6 +79,7 @@ declare module '@theme/DocSidebar' {
     readonly path: string;
     readonly sidebar: readonly PropSidebarItem[];
     readonly sidebarCollapsible?: boolean;
+    readonly autoCollapseSidebar?: boolean;
     readonly onCollapse: () => void;
     readonly isHidden: boolean;
   };

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -282,6 +282,7 @@ const LocaleConfigs = isI18nStaging
   ],
   themeConfig: {
     hideableSidebar: true,
+    autoCollapseSidebar: true,
     colorMode: {
       defaultMode: 'light',
       disableSwitch: false,

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -10,6 +10,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Docusaurus',
+      link: {type: 'link', href: 'https://google.com'},
       items: ['introduction', 'design-principles', 'contributing'],
     },
     {
@@ -21,6 +22,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Guides',
+      link: {type: 'doc', id: 'creating-pages'},
       items: [
         'guides/creating-pages',
         {


### PR DESCRIPTION
###### This is the features for auto collapse and link to category
###### This is features if `https://www.npmjs.com/package/patch-package` doesn't fix our issue easliy

## Go to category feature
- With the go to feature the addition is connected to the `sidebar.js` 

`    {
      type: 'category',
      label: 'Getting Started',
      link: {type: 'doc', id: 'installation'},
      collapsed: false,
      items: ['installation', 'configuration', 'typescript-support'],
    },
`
- There is two types for `link` : `doc` and `link`
- if type is `doc` the second key will be an `id` with the link path as the value
- if type is `link` the second key will be an `href` which will take a url and create a new tab with that url

## Auto collapse 
- With the go to feature the addition is connected to the `docusaurus.config.js`
- By default this is disabled 

`   themeConfig:  {
     autoCollapseSidebar: true,
    },
`
- When an active category is open that category stays open
- but when inactive categories are opened only 1 inactive category will be open at a time.