### PR TITLE
Change to use our Netlify site url

### DIFF
--- a/.github/workflows/lighthouseCI.yml
+++ b/.github/workflows/lighthouseCI.yml
@@ -18,7 +18,7 @@ jobs:
         uses: treosh/lighthouse-ci-action@v3
         with:
           urls: |
-           https://deploy-preview-$PR_NUMBER--docusaurus-2.netlify.app/classic/
+           https://deploy-preview-$PR_NUMBER--goofy-kalam-1b3194.netlify.app/classic/
           configPath: ./.github/workflows/lighthousesrc.json
           uploadArtifacts: true
           temporaryPublicStorage: true

--- a/.github/workflows/lighthouseCI.yml
+++ b/.github/workflows/lighthouseCI.yml
@@ -11,8 +11,8 @@ jobs:
         uses: jakepartusch/wait-for-netlify-action@v1
         id: netlify
         with:
-          site_name: 'docusaurus-2'
-          max_timeout: 600
+          site_name: 'goofy-kalam-1b3194'
+          max_timeout: 1000
       - name: Audit URLs using Lighthouse
         id: lighthouse_audit
         uses: treosh/lighthouse-ci-action@v3

--- a/.github/workflows/lighthouseCI.yml
+++ b/.github/workflows/lighthouseCI.yml
@@ -12,7 +12,7 @@ jobs:
         id: netlify
         with:
           site_name: 'goofy-kalam-1b3194'
-          max_timeout: 1000
+          max_timeout: 1100
       - name: Audit URLs using Lighthouse
         id: lighthouse_audit
         uses: treosh/lighthouse-ci-action@v3


### PR DESCRIPTION
A lighthouse test depends on the Netlify deploy preview.
Changing the url to use our own site - 
